### PR TITLE
Build tasks for PHP QA tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /nbproject/private/
 /vendor/
+cache.properties
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /vendor/
 cache.properties
 
+/build/api
+/build/coverage
+/build/logs
+/build/pdepend
+/build/phpdox

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="name-of-project" default="full-build">
+ <!-- By default, we assume all tools to be on the $PATH -->
+ <property name="pdepend" value="pdepend"/>
+ <property name="phpcpd"  value="phpcpd"/>
+ <property name="phpcs"   value="phpcs"/>
+ <property name="phpdox"  value="phpdox"/>
+ <property name="phploc"  value="phploc"/>
+ <property name="phpmd"   value="phpmd"/>
+ <property name="phpunit" value="phpunit"/>
+
+ <!-- Use this when the tools are located as PHARs in ${basedir}/build/tools
+ <property name="pdepend" value="${basedir}/build/tools/pdepend.phar"/>
+ <property name="phpcpd"  value="${basedir}/build/tools/phpcpd.phar"/>
+ <property name="phpcs"   value="${basedir}/build/tools/phpcs.phar"/>
+ <property name="phpdox"  value="${basedir}/build/tools/phpdox.phar"/>
+ <property name="phploc"  value="${basedir}/build/tools/phploc.phar"/>
+ <property name="phpmd"   value="${basedir}/build/tools/phpmd.phar"/>
+ <property name="phpunit" value="${basedir}/build/tools/phpunit.phar"/> -->
+
+ <!-- Use this when the tools are managed by Composer in ${basedir}/vendor/bin
+ <property name="pdepend" value="${basedir}/vendor/bin/pdepend"/>
+ <property name="phpcpd"  value="${basedir}/vendor/bin/phpcpd"/>
+ <property name="phpcs"   value="${basedir}/vendor/bin/phpcs"/>
+ <property name="phpdox"  value="${basedir}/vendor/bin/phpdox"/>
+ <property name="phploc"  value="${basedir}/vendor/bin/phploc"/>
+ <property name="phpmd"   value="${basedir}/vendor/bin/phpmd"/>
+ <property name="phpunit" value="${basedir}/vendor/bin/phpunit"/> -->
+
+ <target name="full-build"
+         depends="prepare,static-analysis,phpunit,phpdox,-check-failure"
+         description="Performs static analysis, runs the tests, and generates project documentation"/>
+
+ <target name="full-build-parallel"
+         depends="prepare,static-analysis-parallel,phpunit,phpdox,-check-failure"
+         description="Performs static analysis (executing the tools in parallel), runs the tests, and generates project documentation"/>
+
+ <target name="quick-build"
+         depends="prepare,lint,phpunit-no-coverage"
+         description="Performs a lint check and runs the tests (without generating code coverage reports)"/>
+
+ <target name="static-analysis"
+         depends="lint,phploc-ci,pdepend,phpmd-ci,phpcs-ci,phpcpd-ci"
+         description="Performs static analysis" />
+
+ <!-- Adjust the threadCount attribute's value to the number of CPUs -->
+ <target name="static-analysis-parallel"
+         description="Performs static analysis (executing the tools in parallel)">
+  <parallel threadCount="2">
+   <sequential>
+    <antcall target="pdepend"/>
+    <antcall target="phpmd-ci"/>
+   </sequential>
+   <antcall target="lint"/>
+   <antcall target="phpcpd-ci"/>
+   <antcall target="phpcs-ci"/>
+   <antcall target="phploc-ci"/>
+  </parallel>
+ </target>
+
+ <target name="clean"
+         unless="clean.done"
+         description="Cleanup build artifacts">
+  <delete dir="${basedir}/build/api"/>
+  <delete dir="${basedir}/build/coverage"/>
+  <delete dir="${basedir}/build/logs"/>
+  <delete dir="${basedir}/build/pdepend"/>
+  <delete dir="${basedir}/build/phpdox"/>
+  <property name="clean.done" value="true"/>
+ </target>
+
+ <target name="prepare"
+         unless="prepare.done"
+         depends="clean"
+         description="Prepare for build">
+  <mkdir dir="${basedir}/build/api"/>
+  <mkdir dir="${basedir}/build/coverage"/>
+  <mkdir dir="${basedir}/build/logs"/>
+  <mkdir dir="${basedir}/build/pdepend"/>
+  <mkdir dir="${basedir}/build/phpdox"/>
+  <property name="prepare.done" value="true"/>
+ </target>
+
+ <target name="lint"
+         unless="lint.done"
+         description="Perform syntax check of sourcecode files">
+  <apply executable="php" taskname="lint">
+   <arg value="-l" />
+
+   <fileset dir="${basedir}/src">
+    <include name="**/*.php" />
+    <modified />
+   </fileset>
+
+   <fileset dir="${basedir}/tests">
+    <include name="**/*.php" />
+    <modified />
+   </fileset>
+  </apply>
+
+  <property name="lint.done" value="true"/>
+ </target>
+
+ <target name="phploc"
+         unless="phploc.done"
+         description="Measure project size using PHPLOC and print human readable output. Intended for usage on the command line.">
+  <exec executable="${phploc}" taskname="phploc">
+   <arg value="--count-tests" />
+   <arg path="${basedir}/src" />
+   <arg path="${basedir}/tests" />
+  </exec>
+
+  <property name="phploc.done" value="true"/>
+ </target>
+
+ <target name="phploc-ci"
+         unless="phploc.done"
+         depends="prepare"
+         description="Measure project size using PHPLOC and log result in CSV and XML format. Intended for usage within a continuous integration environment.">
+  <exec executable="${phploc}" taskname="phploc">
+   <arg value="--count-tests" />
+   <arg value="--log-csv" />
+   <arg path="${basedir}/build/logs/phploc.csv" />
+   <arg value="--log-xml" />
+   <arg path="${basedir}/build/logs/phploc.xml" />
+   <arg path="${basedir}/src" />
+   <arg path="${basedir}/tests" />
+  </exec>
+
+  <property name="phploc.done" value="true"/>
+ </target>
+
+ <target name="pdepend"
+         unless="pdepend.done"
+         depends="prepare"
+         description="Calculate software metrics using PHP_Depend and log result in XML format. Intended for usage within a continuous integration environment.">
+  <exec executable="${pdepend}" taskname="pdepend">
+   <arg value="--jdepend-xml=${basedir}/build/logs/jdepend.xml" />
+   <arg value="--jdepend-chart=${basedir}/build/pdepend/dependencies.svg" />
+   <arg value="--overview-pyramid=${basedir}/build/pdepend/overview-pyramid.svg" />
+   <arg path="${basedir}/src" />
+  </exec>
+
+  <property name="pdepend.done" value="true"/>
+ </target>
+
+ <target name="phpmd"
+         unless="phpmd.done"
+         description="Perform project mess detection using PHPMD and print human readable output. Intended for usage on the command line before committing.">
+  <exec executable="${phpmd}" taskname="phpmd">
+   <arg path="${basedir}/src" />
+   <arg value="text" />
+   <arg path="${basedir}/build/phpmd.xml" />
+  </exec>
+
+  <property name="phpmd.done" value="true"/>
+ </target>
+
+ <target name="phpmd-ci"
+         unless="phpmd.done"
+         depends="prepare"
+         description="Perform project mess detection using PHPMD and log result in XML format. Intended for usage within a continuous integration environment.">
+  <exec executable="${phpmd}" taskname="phpmd">
+   <arg path="${basedir}/src" />
+   <arg value="xml" />
+   <arg path="${basedir}/build/phpmd.xml" />
+   <arg value="--reportfile" />
+   <arg path="${basedir}/build/logs/pmd.xml" />
+  </exec>
+
+  <property name="phpmd.done" value="true"/>
+ </target>
+
+ <target name="phpcs"
+         unless="phpcs.done"
+         description="Find coding standard violations using PHP_CodeSniffer and print human readable output. Intended for usage on the command line before committing.">
+  <exec executable="${phpcs}" taskname="phpcs">
+   <arg value="--standard=PSR2" />
+   <arg value="--extensions=php" />
+   <arg value="--ignore=autoload.php" />
+   <arg path="${basedir}/src" />
+   <arg path="${basedir}/tests" />
+  </exec>
+
+  <property name="phpcs.done" value="true"/>
+ </target>
+
+ <target name="phpcs-ci"
+         unless="phpcs.done"
+         depends="prepare"
+         description="Find coding standard violations using PHP_CodeSniffer and log result in XML format. Intended for usage within a continuous integration environment.">
+  <exec executable="${phpcs}" output="/dev/null" taskname="phpcs">
+   <arg value="--report=checkstyle" />
+   <arg value="--report-file=${basedir}/build/logs/checkstyle.xml" />
+   <arg value="--standard=PSR2" />
+   <arg value="--extensions=php" />
+   <arg value="--ignore=autoload.php" />
+   <arg path="${basedir}/src" />
+   <arg path="${basedir}/tests" />
+  </exec>
+
+  <property name="phpcs.done" value="true"/>
+ </target>
+
+ <target name="phpcpd"
+         unless="phpcpd.done"
+         description="Find duplicate code using PHPCPD and print human readable output. Intended for usage on the command line before committing.">
+  <exec executable="${phpcpd}" taskname="phpcpd">
+   <arg path="${basedir}/src" />
+  </exec>
+
+  <property name="phpcpd.done" value="true"/>
+ </target>
+
+ <target name="phpcpd-ci"
+         unless="phpcpd.done"
+         depends="prepare"
+         description="Find duplicate code using PHPCPD and log result in XML format. Intended for usage within a continuous integration environment.">
+  <exec executable="${phpcpd}" taskname="phpcpd">
+   <arg value="--log-pmd" />
+   <arg path="${basedir}/build/logs/pmd-cpd.xml" />
+   <arg path="${basedir}/src" />
+  </exec>
+
+  <property name="phpcpd.done" value="true"/>
+ </target>
+
+ <target name="phpunit"
+         unless="phpunit.done"
+         depends="prepare"
+         description="Run unit tests with PHPUnit">
+  <exec executable="${phpunit}" resultproperty="result.phpunit" taskname="phpunit">
+   <arg value="--configuration"/>
+   <arg path="${basedir}/build/phpunit.xml"/>
+  </exec>
+
+  <property name="phpunit.done" value="true"/>
+ </target>
+
+ <target name="phpunit-no-coverage"
+         unless="phpunit.done"
+         depends="prepare"
+         description="Run unit tests with PHPUnit (without generating code coverage reports)">
+  <exec executable="${phpunit}" failonerror="true" taskname="phpunit">
+   <arg value="--configuration"/>
+   <arg path="${basedir}/build/phpunit.xml"/>
+   <arg value="--no-coverage"/>
+  </exec>
+
+  <property name="phpunit.done" value="true"/>
+ </target>
+
+ <target name="phpdox"
+         unless="phpdox.done"
+         depends="phploc-ci,phpcs-ci,phpmd-ci"
+         description="Generate project documentation using phpDox">
+  <exec executable="${phpdox}" dir="${basedir}/build" taskname="phpdox"/>
+
+  <property name="phpdox.done" value="true"/>
+ </target>
+
+ <target name="-check-failure">
+  <fail message="PHPUnit did not finish successfully">
+   <condition>
+    <not>
+     <equals arg1="${result.phpunit}" arg2="0"/>
+    </not>
+   </condition>
+  </fail>
+ </target>
+</project>
+

--- a/build.xml
+++ b/build.xml
@@ -1,31 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="name-of-project" default="full-build">
- <!-- By default, we assume all tools to be on the $PATH -->
- <property name="pdepend" value="pdepend"/>
- <property name="phpcpd"  value="phpcpd"/>
- <property name="phpcs"   value="phpcs"/>
- <property name="phpdox"  value="phpdox"/>
- <property name="phploc"  value="phploc"/>
- <property name="phpmd"   value="phpmd"/>
- <property name="phpunit" value="phpunit"/>
-
- <!-- Use this when the tools are located as PHARs in ${basedir}/build/tools
- <property name="pdepend" value="${basedir}/build/tools/pdepend.phar"/>
- <property name="phpcpd"  value="${basedir}/build/tools/phpcpd.phar"/>
- <property name="phpcs"   value="${basedir}/build/tools/phpcs.phar"/>
- <property name="phpdox"  value="${basedir}/build/tools/phpdox.phar"/>
- <property name="phploc"  value="${basedir}/build/tools/phploc.phar"/>
- <property name="phpmd"   value="${basedir}/build/tools/phpmd.phar"/>
- <property name="phpunit" value="${basedir}/build/tools/phpunit.phar"/> -->
-
- <!-- Use this when the tools are managed by Composer in ${basedir}/vendor/bin
+ <!-- Use this when the tools are managed by Composer in ${basedir}/vendor/bin -->
  <property name="pdepend" value="${basedir}/vendor/bin/pdepend"/>
  <property name="phpcpd"  value="${basedir}/vendor/bin/phpcpd"/>
  <property name="phpcs"   value="${basedir}/vendor/bin/phpcs"/>
  <property name="phpdox"  value="${basedir}/vendor/bin/phpdox"/>
  <property name="phploc"  value="${basedir}/vendor/bin/phploc"/>
  <property name="phpmd"   value="${basedir}/vendor/bin/phpmd"/>
- <property name="phpunit" value="${basedir}/vendor/bin/phpunit"/> -->
+ <property name="phpunit" value="${basedir}/vendor/bin/phpunit"/>
 
  <target name="full-build"
          depends="prepare,static-analysis,phpunit,phpdox,-check-failure"

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="name-of-project" default="full-build">
+<project name="php-jenkins-example" default="full-build">
  <!-- Use this when the tools are managed by Composer in ${basedir}/vendor/bin -->
  <property name="pdepend" value="${basedir}/vendor/bin/pdepend"/>
  <property name="phpcpd"  value="${basedir}/vendor/bin/phpcpd"/>

--- a/build.xml
+++ b/build.xml
@@ -236,7 +236,10 @@
          unless="phpdox.done"
          depends="phploc-ci,phpcs-ci,phpmd-ci"
          description="Generate project documentation using phpDox">
-  <exec executable="${phpdox}" dir="${basedir}/build" taskname="phpdox"/>
+  <exec executable="${phpdox}" taskname="phpdox">
+   <arg value="--file"/>
+   <arg path="${basedir}/build/phpdox.xml"/>
+  </exec>
 
   <property name="phpdox.done" value="true"/>
  </target>

--- a/build.xml
+++ b/build.xml
@@ -10,15 +10,15 @@
  <property name="phpunit" value="${basedir}/vendor/bin/phpunit"/>
 
  <target name="full-build"
-         depends="prepare,static-analysis,phpunit,phpdox,-check-failure"
+         depends="prepare,static-analysis,phpunit-ci,phpdox,-check-failure"
          description="Performs static analysis, runs the tests, and generates project documentation"/>
 
  <target name="full-build-parallel"
-         depends="prepare,static-analysis-parallel,phpunit,phpdox,-check-failure"
+         depends="prepare,static-analysis-parallel,phpunit-ci,phpdox,-check-failure"
          description="Performs static analysis (executing the tools in parallel), runs the tests, and generates project documentation"/>
 
  <target name="quick-build"
-         depends="prepare,lint,phpunit-no-coverage"
+         depends="prepare,lint,phpunit"
          description="Performs a lint check and runs the tests (without generating code coverage reports)"/>
 
  <target name="static-analysis"
@@ -207,7 +207,7 @@
   <property name="phpcpd.done" value="true"/>
  </target>
 
- <target name="phpunit"
+ <target name="phpunit-ci"
          unless="phpunit.done"
          depends="prepare"
          description="Run unit tests with PHPUnit">
@@ -219,7 +219,7 @@
   <property name="phpunit.done" value="true"/>
  </target>
 
- <target name="phpunit-no-coverage"
+ <target name="phpunit"
          unless="phpunit.done"
          depends="prepare"
          description="Run unit tests with PHPUnit (without generating code coverage reports)">

--- a/build.xml
+++ b/build.xml
@@ -213,7 +213,7 @@
          description="Run unit tests with PHPUnit">
   <exec executable="${phpunit}" resultproperty="result.phpunit" taskname="phpunit">
    <arg value="--configuration"/>
-   <arg path="${basedir}/build/phpunit.xml"/>
+   <arg path="${basedir}/phpunit.xml.dist"/>
   </exec>
 
   <property name="phpunit.done" value="true"/>
@@ -225,7 +225,7 @@
          description="Run unit tests with PHPUnit (without generating code coverage reports)">
   <exec executable="${phpunit}" failonerror="true" taskname="phpunit">
    <arg value="--configuration"/>
-   <arg path="${basedir}/build/phpunit.xml"/>
+   <arg path="${basedir}/phpunit.xml.dist"/>
    <arg value="--no-coverage"/>
   </exec>
 

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="php-jenkins-example" default="full-build">
+ <property name="basedir" value="."/>
  <!-- Use this when the tools are managed by Composer in ${basedir}/vendor/bin -->
  <property name="pdepend" value="${basedir}/vendor/bin/pdepend"/>
  <property name="phpcpd"  value="${basedir}/vendor/bin/phpcpd"/>

--- a/build/phpdox.xml
+++ b/build/phpdox.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpdox xmlns="http://xml.phpdox.net/config">
+ <project name="php-jenkins-example" source="${basedir}/../src" workdir="build/phpdox">
+  <collector publiconly="false">
+   <include mask="*.php" />
+  </collector>
+
+  <generator output="build">
+   <build engine="html" enabled="true" output="api">
+    <file extension="html" />
+   </build>
+  </generator>
+ </project>
+</phpdox>

--- a/build/phpmd.xml
+++ b/build/phpmd.xml
@@ -1,0 +1,20 @@
+<ruleset name="php-jenkins-example-coding-standard"
+  xmlns="http://pmd.sf.net/ruleset/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
+                      http://pmd.sf.net/ruleset_xml_schema.xsd"
+  xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+  <description>Description of your coding standard</description>
+
+  <!-- Code Size Rules, see http://phpmd.org/rules/codesize.html -->
+  <rule ref="rulesets/codesize.xml" />
+
+  <!-- Design Rules, see http://phpmd.org/rules/design.html -->
+  <rule ref="rulesets/design.xml" />
+
+  <!-- Unused Code Rules, see http://phpmd.org/rules/unusedcode.html -->
+  <rule ref="rulesets/unusedcode.xml" />
+
+  <!-- Unused Code Rules, see http://phpmd.org/rules/controversial.html -->
+  <rule ref="rulesets/controversial.xml" />
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         strict="true"
+         verbose="true">
+       
+  <testsuites>
+    <testsuite name="php-jenkins-example">
+      <directory suffix="Test.php">tests/</directory>
+    </testsuite>
+  </testsuites>
+
+  <logging>
+    <log type="coverage-html" target="build/coverage"/>
+    <log type="coverage-clover" target="build/logs/clover.xml"/>
+    <log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
+    <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+  </logging>
+
+  <filter>
+    <whitelist addUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">src</directory>
+      <exclude>
+        <file>src/bootstrap.php</file>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
Setup the base PHP Quality Assurance tools and Ant build script to run them. It is based on http://jenkins-php.org/configuration.html template, with tweaks to make it work actually.
